### PR TITLE
feat(ci): upgrade Node.js to 22 and update Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ------------------------------------------------------------------
       # 1. Build Backend (Rust -> Lambda bootstrap)
@@ -29,7 +29,7 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -54,9 +54,9 @@ jobs:
       # 2. Build Frontend (React -> static files)
       # ------------------------------------------------------------------
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
CI/CDワークフローのメンテナンス：
- Node.js バージョンを 20 から 22 へアップデート
- actions/checkout, actions/setup-node, actions/cache を最新バージョンへ更新