### PR TITLE
fix(ci): add missing react-is dependency to frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "lucide-react": "^0.574.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.4",
+        "react-is": "^19.2.4",
         "recharts": "^3.7.0"
       },
       "devDependencies": {
@@ -9012,6 +9013,12 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "lucide-react": "^0.574.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.4",
+    "react-is": "^19.2.4",
     "recharts": "^3.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
AWSデプロイ（Viteビルド）時に発生していた Rollup failed to resolve import 'react-is' エラーを修正するため、フロントエンドに react-is を追加しました。