### PR TITLE
feat(frontend): add rep options and skip exercise

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -129,7 +129,7 @@ export default function App() {
     aiRecommendation, isAiLoading, aiError, showAiModal, setShowAiModal,
     fetchAIRecommendation, triggerMenuGeneration,
 
-    startMenu, handleLog, finishRest,
+    startMenu, handleLog, finishRest, skipExercise,
     currentMenuExercise, totalSetsForCurrent, currentRestDuration
   } = useWorkoutSession(session, vibrate, showToast);
 
@@ -301,7 +301,15 @@ export default function App() {
       {/* Exercise Card */}
       <div className="glass-card rounded-[2.5rem] p-7 border border-slate-700/50 shadow-2xl relative mb-6">
         <div className="flex justify-between items-start mb-2">
-          <h2 className="text-xl font-black leading-tight">{currentMenuExercise?.exerciseName}</h2>
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-black leading-tight">{currentMenuExercise?.exerciseName}</h2>
+            <button
+              onClick={skipExercise}
+              className="px-3 py-1 bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600 text-slate-500 dark:text-slate-400 text-[10px] font-black rounded-lg transition-colors"
+            >
+              SKIP
+            </button>
+          </div>
           <span className="bg-orange-500 text-white text-[10px] font-black px-3 py-1 rounded-full">{currentExerciseIndex + 1}/{activeMenu.exercises.length}</span>
         </div>
         <p className="text-[10px] font-bold text-blue-400 uppercase tracking-widest italic mb-6">{currentMenuExercise?.notes}</p>

--- a/frontend/src/components/LoggingFlow.tsx
+++ b/frontend/src/components/LoggingFlow.tsx
@@ -9,7 +9,7 @@ interface LoggingFlowProps {
 }
 
 export default function LoggingFlow({ theme = 'dark', reps: selectedReps, isLoading = false, onRepsChange, onLog }: LoggingFlowProps) {
-    const repsOptions = Array.from({ length: 8 }, (_, i) => i + 8); // 8 to 15 reps
+    const repsOptions = Array.from({ length: 16 }, (_, i) => i + 1); // 1 to 16 reps
 
     const rpeOptions: { level: RpeLevel; label: string; icon: string; color: string }[] = [
         { level: 'easy', label: '余裕', icon: '😊', color: 'bg-green-500/20 text-green-400 border-green-500/50' },

--- a/frontend/src/hooks/useWorkoutSession.ts
+++ b/frontend/src/hooks/useWorkoutSession.ts
@@ -158,6 +158,19 @@ export function useWorkoutSession(session: CognitoSession | null, vibrate: (patt
         }
     }, [activeMenu, currentExerciseIndex, currentSet, totalSetsForCurrent]);
 
+    const skipExercise = useCallback(() => {
+        if (!activeMenu) return;
+        setIsResting(false);
+        if (currentExerciseIndex < activeMenu.exercises.length - 1) {
+            const nextIdx = currentExerciseIndex + 1;
+            setCurrentExerciseIndex(nextIdx);
+            setCurrentSet(1);
+            setWeight(activeMenu.exercises[nextIdx].recommendedWeight);
+        } else {
+            setIsSessionComplete(true);
+        }
+    }, [activeMenu, currentExerciseIndex]);
+
     return {
         history, setHistory,
         activeMenu, setActiveMenu,
@@ -171,7 +184,7 @@ export function useWorkoutSession(session: CognitoSession | null, vibrate: (patt
         aiRecommendation, isAiLoading, aiError, showAiModal, setShowAiModal,
         fetchAIRecommendation, triggerMenuGeneration,
 
-        startMenu, handleLog, finishRest,
+        startMenu, handleLog, finishRest, skipExercise,
         currentMenuExercise, totalSetsForCurrent, currentRestDuration
     };
 }


### PR DESCRIPTION
- REP数の選択肢を1〜16に拡張
- 種目のスキップ機能を追加