### PR TITLE
fix(infra): resolve deprecated Origin and AWS config usages

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Error> {
         .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
         .init();
 
-    let config = aws_config::load_from_env().await;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let db_client = DynamoClient::new(&config);
     let http_client = HttpClient::new();
 

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -174,7 +174,7 @@ export class InfraStack extends cdk.Stack {
 
     const distribution = new cloudfront.Distribution(this, 'Distribution', {
       defaultBehavior: {
-        origin: new origins.S3Origin(websiteBucket),
+        origin: origins.S3BucketOrigin.withOriginAccessControl(websiteBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
       },
       priceClass: cloudfront.PriceClass.PRICE_CLASS_200,


### PR DESCRIPTION
## 概要
- CDKの `S3Origin` が非推奨になったため、暗黙のアクセスインターフェースではなく推奨される `S3BucketOrigin.withOriginAccessControl` に移行
- バックエンドの `aws_config::load_from_env` 非推奨警告を解消し、 `load_defaults` へ移行